### PR TITLE
Add generic ID support

### DIFF
--- a/example/main.ts
+++ b/example/main.ts
@@ -4,7 +4,7 @@ const apiKey = import.meta.env.VITE_PUMPROOM_API_KEY;
 const realm = import.meta.env.VITE_PUMPROOM_REALM;
 
 const profile = {
-    email: 'demo_user@inzhenerka.tech',
+    id: 'demo_user@inzhenerka.tech',
     name: 'demo_user',
 };
 

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     <section class="my-5">
         <h2 class="h4 mb-3">Начало работы</h2>
         <div class="alert alert-info" role="alert">
-            Прежде чем начать, сообщите менеджеру PumpRoom ваш email, чтобы получить доступ
+            Прежде чем начать, сообщите менеджеру PumpRoom ваш идентификатор (например email), чтобы получить доступ
             к <a href="http://admin.pumproom.tech/" target="_blank">админке</a>.
             Там в разделе Интеграция вы найдете API-ключ <code>apiKey</code> и идентификатор школы <code>realm</code>.
         </div>
@@ -60,7 +60,7 @@
 &lt;script&gt;
   PumpRoomSdk.init({ apiKey: 'ВАШ_КЛЮЧ', realm: 'ВАШ_ID' });
   PumpRoomSdk.authenticate({
-        lms: { email: 'ПОЧТА_СТУДЕНТА', name: 'ИМЯ_СТУДЕНТА' },
+        lms: { id: 'ID_СТУДЕНТА', name: 'ИМЯ_СТУДЕНТА' },
   }).catch(console.error);
 &lt;/script&gt;</code></pre>
                 <p>Альтернативный способ (более современный):</p>
@@ -69,7 +69,7 @@
 
   init({ apiKey: 'ВАШ_КЛЮЧ', realm: 'ВАШ_ID' });
   authenticate({
-        lms: { email: 'ПОЧТА_СТУДЕНТА', name: 'ИМЯ_СТУДЕНТА' },
+        lms: { id: 'ID_СТУДЕНТА', name: 'ИМЯ_СТУДЕНТА' },
   }).catch(console.error);
 &lt;/script></code></pre>
             </div>
@@ -85,7 +85,7 @@
 
 init({ apiKey: 'ВАШ_КЛЮЧ', realm: 'ВАШ_ID' });
 authenticate({
-    lms: { email: 'ПОЧТА_СТУДЕНТА', name: 'ИМЯ_СТУДЕНТА' },
+    lms: { id: 'ID_СТУДЕНТА', name: 'ИМЯ_СТУДЕНТА' },
 }).catch(console.error);</code></pre>
             </div>
         </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,8 +47,22 @@ export interface TildaProfileInput {
 }
 
 export interface LMSProfileInput {
-    email: string;
+    /**
+     * Unique identifier of the user within LMS.
+     * Can be any string. When not provided and a valid email is passed via
+     * `email`, it will be used as the identifier.
+     */
+    id?: string;
+
+    /**
+     * Optional email that can also act as identifier if `id` is missing.
+     */
+    email?: string;
+
+    /** Display name of the user */
     name: string;
+
+    /** Optional link to avatar */
     photo_url?: string | null;
 }
 

--- a/tests/listener.test.ts
+++ b/tests/listener.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { authenticate } from '../src/auth.js';
 import { setConfig } from '../src/state.js';
+import { initApiClient } from '../src/api-client.js';
 import * as messaging from '../src/messaging.js';
 
 beforeEach(() => {
   setConfig({ apiKey: 'key', realm: 'test', cacheUser: false });
+  initApiClient('key');
   vi.restoreAllMocks();
 });
 


### PR DESCRIPTION
## Summary
- add `id` to `LMSProfileInput`
- treat `email` as identifier if `id` is absent and valid
- warn when both `id` and `email` are provided
- update examples and docs
- update tests and init API client for tests

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_6869b9db72dc8324ba9c8c93596d17ae