### PR TITLE
Fix failing tests and improve docs

### DIFF
--- a/example/main.ts
+++ b/example/main.ts
@@ -17,11 +17,18 @@ PumpRoomSdk.init({
 PumpRoomSdk.authenticate({lms: profile}).catch(console.error);
 
 PumpRoomSdk.setOnInitCallback(async (data) => {
-    console.log('Instance initialized:', data);
-    console.log('All instances', PumpRoomSdk.getInstances())
+    console.log('[CB] Instance initialized:', data);
+    console.log('[CB] All instances', PumpRoomSdk.getInstances())
 });
 
-
 PumpRoomSdk.setOnTaskLoadedCallback(async (data) => {
-    console.log('Task loaded:', data);
+    console.log('[CB] Task loaded:', data);
+});
+
+PumpRoomSdk.setOnTaskSubmittedCallback(async (data) => {
+    console.log('[CB] Task submitted:', data);
+});
+
+PumpRoomSdk.setOnResultReadyCallback(async (data) => {
+    console.log('[CB] Result ready:', data);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,12 @@ export {getCurrentUser} from './state.ts';
 export {authenticate, setUser} from './auth.ts';
 export {getVersion} from './version.ts';
 export {getInstances} from './instance.ts';
-export {setOnInitCallback, setOnTaskLoadedCallback} from './callbacks.ts';
+export {
+    setOnInitCallback, 
+    setOnTaskLoadedCallback, 
+    setOnTaskSubmittedCallback, 
+    setOnResultReadyCallback
+} from './callbacks.ts';
 export type {
     PumpRoomConfig,
     PumpRoomUser,
@@ -31,7 +36,12 @@ export type {
     InstanceContext,
     OnInitCallback,
     OnTaskLoadedCallback,
+    OnTaskSubmittedCallback,
+    OnResultReadyCallback,
     EnvironmentData,
+    TaskDetails,
+    LoadedTaskData,
+    ResultData,
 } from './types/index.ts';
 
 console.debug('PumpRoom SDK v' + getVersion() + ' loaded');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -270,6 +270,10 @@ export interface SubmissionResult {
     stdout: string | null;
 }
 
+/**
+ * Data provided to callbacks after the SDK receives environment information.
+ */
 export interface EnvironmentData {
+    /** Context information about the current instance */
     instanceContext: InstanceContext;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -236,13 +236,13 @@ export interface InstanceContext {
 export type OnInitCallback = (data: EnvironmentData) => void | Promise<void>;
 
 /** Callback function type for when a task is loaded */
-export type OnTaskLoadedCallback = (
-    data: {
-        instanceContext: InstanceContext,
-        task: TaskDetails
-    }
-) => void | Promise<void>;
+export type OnTaskLoadedCallback = (data: LoadedTaskData) => void | Promise<void>;
 
+/** Callback function type for when a task is submitted */
+export type OnTaskSubmittedCallback = (data: LoadedTaskData) => void | Promise<void>;
+
+/** Callback function type for when a result is ready */
+export type OnResultReadyCallback = (data: ResultData) => void | Promise<void>;
 
 /**
  * Payload for fullscreen toggle messages
@@ -276,4 +276,14 @@ export interface SubmissionResult {
 export interface EnvironmentData {
     /** Context information about the current instance */
     instanceContext: InstanceContext;
+}
+
+export interface LoadedTaskData {
+    instanceContext: InstanceContext;
+    task: TaskDetails;
+}
+
+export interface ResultData {
+    instanceContext: InstanceContext,
+    result: SubmissionResult,
 }

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,10 +1,9 @@
 import {
-    InstanceContext,
     PumpRoomUser,
     TaskStatus,
     EnvironmentData,
-    TaskDetails,
-    SubmissionResult,
+    ResultData,
+    LoadedTaskData,
 } from "./index.ts";
 
 export type PumpRoomMessageType =
@@ -108,26 +107,17 @@ export interface ReportStatusMessage extends PumproomMessage {
 
 export interface OnTaskLoadedMessage extends PumproomMessage {
     type: 'onTaskLoaded';
-    payload: {
-        instanceContext: InstanceContext,
-        task: TaskDetails,
-    };
+    payload: LoadedTaskData;
 }
 
 export interface OnTaskSubmittedMessage extends PumproomMessage {
     type: 'onTaskSubmitted';
-    payload: {
-        instanceContext: InstanceContext,
-        task: TaskDetails,
-    }
+    payload: LoadedTaskData;
 }
 
 export interface OnResultReadyMessage extends PumproomMessage {
     type: 'onResultReady';
-    payload: {
-        instanceContext: InstanceContext,
-        result: SubmissionResult,
-    }
+    payload: ResultData;
 }
 
 

--- a/tests/callbacks.test.ts
+++ b/tests/callbacks.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { setOnInitCallback, setOnTaskLoadedCallback } from '../src/callbacks.ts';
+import {
+  setOnInitCallback,
+  setOnTaskLoadedCallback,
+  executeOnInitCallback,
+  handleTaskLoadedMessage,
+} from '../src/callbacks.ts';
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -22,12 +27,8 @@ describe('callbacks module', () => {
     // Set the callback
     setOnInitCallback(mockCallback);
 
-    // Simulate the execution of the callback
-    // This is done by dispatching a message event in the actual code
-    // but we'll directly call the internal function for testing
-    // We need to access the internal function, so we'll use the module's exports
-    const callbacksModule = require('../src/callbacks.ts');
-    callbacksModule.executeOnInitCallback(mockInstanceContext);
+    // Directly execute the callback using the internal helper
+    executeOnInitCallback(mockInstanceContext);
 
     // Verify the callback was called with the correct instance context
     expect(mockCallback).toHaveBeenCalledWith(mockInstanceContext);
@@ -54,8 +55,7 @@ describe('callbacks module', () => {
     setOnInitCallback(mockAsyncCallback);
 
     // Simulate the execution of the callback
-    const callbacksModule = require('../src/callbacks.ts');
-    callbacksModule.executeOnInitCallback(mockInstanceContext);
+    executeOnInitCallback(mockInstanceContext);
 
     // Verify the callback was called with the correct instance context
     expect(mockAsyncCallback).toHaveBeenCalledWith(mockInstanceContext);
@@ -103,8 +103,7 @@ describe('callbacks module', () => {
     });
 
     // Simulate handling the message
-    const callbacksModule = require('../src/callbacks.ts');
-    callbacksModule.handleTaskLoadedMessage(event);
+    handleTaskLoadedMessage(event);
 
     // Verify the callback was called with the correct payload
     expect(mockCallback).toHaveBeenCalledWith({
@@ -153,8 +152,7 @@ describe('callbacks module', () => {
     });
 
     // Simulate handling the message
-    const callbacksModule = require('../src/callbacks.ts');
-    callbacksModule.handleTaskLoadedMessage(event);
+    handleTaskLoadedMessage(event);
 
     // Verify the callback was called with the correct payload
     expect(mockAsyncCallback).toHaveBeenCalledWith({

--- a/tests/callbacks.test.ts
+++ b/tests/callbacks.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   setOnInitCallback,
   setOnTaskLoadedCallback,
+  setOnTaskSubmittedCallback,
+  setOnResultReadyCallback,
   executeOnInitCallback,
   handleTaskLoadedMessage,
+  handleTaskSubmittedMessage,
+  handleResultReadyMessage,
 } from '../src/callbacks.ts';
 
 beforeEach(() => {
@@ -158,6 +162,212 @@ describe('callbacks module', () => {
     expect(mockAsyncCallback).toHaveBeenCalledWith({
       instanceContext: mockInstanceContext,
       task: mockTask
+    });
+
+    // Wait for any pending promises to resolve
+    await new Promise(resolve => setTimeout(resolve, 20));
+
+    // Verify the callback was called exactly once
+    expect(mockAsyncCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('executes synchronous onTaskSubmittedCallback when onTaskSubmitted message is received', () => {
+    // Create a mock instance context and task
+    const mockInstanceContext = {
+      instanceUid: 'test-instance-uid',
+      repoName: 'test-repo',
+      taskName: 'test-task',
+      realm: 'test-realm',
+      tags: 'test-tags'
+    };
+
+    const mockTask = {
+      uid: 'test-task-uid',
+      description: 'Test task description'
+    };
+
+    // Create a mock callback
+    const mockCallback = vi.fn();
+
+    // Set the callback
+    setOnTaskSubmittedCallback(mockCallback);
+
+    // Create and dispatch a onTaskSubmitted message event with the mock instance context and task
+    const event = new MessageEvent('message', {
+      data: { 
+        service: 'pumproom', 
+        type: 'onTaskSubmitted',
+        payload: {
+          instanceContext: mockInstanceContext,
+          task: mockTask
+        }
+      },
+      origin: 'https://pumproom.tech',
+      source: window
+    });
+
+    // Simulate handling the message
+    handleTaskSubmittedMessage(event);
+
+    // Verify the callback was called with the correct payload
+    expect(mockCallback).toHaveBeenCalledWith({
+      instanceContext: mockInstanceContext,
+      task: mockTask
+    });
+  });
+
+  it('executes asynchronous onTaskSubmittedCallback when onTaskSubmitted message is received', async () => {
+    // Create a mock instance context and task
+    const mockInstanceContext = {
+      instanceUid: 'async-test-instance-uid',
+      repoName: 'async-test-repo',
+      taskName: 'async-test-task',
+      realm: 'async-test-realm',
+      tags: 'async-test-tags'
+    };
+
+    const mockTask = {
+      uid: 'async-test-task-uid',
+      description: 'Async test task description'
+    };
+
+    // Create a mock async callback that returns a promise
+    const mockAsyncCallback = vi.fn().mockImplementation(async (payload) => {
+      // Simulate async operation
+      await new Promise(resolve => setTimeout(resolve, 10));
+      return payload;
+    });
+
+    // Set the async callback
+    setOnTaskSubmittedCallback(mockAsyncCallback);
+
+    // Create and dispatch a onTaskSubmitted message event with the mock instance context and task
+    const event = new MessageEvent('message', {
+      data: { 
+        service: 'pumproom', 
+        type: 'onTaskSubmitted',
+        payload: {
+          instanceContext: mockInstanceContext,
+          task: mockTask
+        }
+      },
+      origin: 'https://pumproom.tech',
+      source: window
+    });
+
+    // Simulate handling the message
+    handleTaskSubmittedMessage(event);
+
+    // Verify the callback was called with the correct payload
+    expect(mockAsyncCallback).toHaveBeenCalledWith({
+      instanceContext: mockInstanceContext,
+      task: mockTask
+    });
+
+    // Wait for any pending promises to resolve
+    await new Promise(resolve => setTimeout(resolve, 20));
+
+    // Verify the callback was called exactly once
+    expect(mockAsyncCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('executes synchronous onResultReadyCallback when onResultReady message is received', () => {
+    // Create a mock instance context and result
+    const mockInstanceContext = {
+      instanceUid: 'test-instance-uid',
+      repoName: 'test-repo',
+      taskName: 'test-task',
+      realm: 'test-realm',
+      tags: 'test-tags'
+    };
+
+    const mockResult = {
+      taskUid: 'test-task-uid',
+      submissionUid: 'test-submission-uid',
+      status: 'success',
+      message: 'Test completed successfully',
+      stdout: 'Test output'
+    };
+
+    // Create a mock callback
+    const mockCallback = vi.fn();
+
+    // Set the callback
+    setOnResultReadyCallback(mockCallback);
+
+    // Create and dispatch a onResultReady message event with the mock instance context and result
+    const event = new MessageEvent('message', {
+      data: { 
+        service: 'pumproom', 
+        type: 'onResultReady',
+        payload: {
+          instanceContext: mockInstanceContext,
+          result: mockResult
+        }
+      },
+      origin: 'https://pumproom.tech',
+      source: window
+    });
+
+    // Simulate handling the message
+    handleResultReadyMessage(event);
+
+    // Verify the callback was called with the correct payload
+    expect(mockCallback).toHaveBeenCalledWith({
+      instanceContext: mockInstanceContext,
+      result: mockResult
+    });
+  });
+
+  it('executes asynchronous onResultReadyCallback when onResultReady message is received', async () => {
+    // Create a mock instance context and result
+    const mockInstanceContext = {
+      instanceUid: 'async-test-instance-uid',
+      repoName: 'async-test-repo',
+      taskName: 'async-test-task',
+      realm: 'async-test-realm',
+      tags: 'async-test-tags'
+    };
+
+    const mockResult = {
+      taskUid: 'async-test-task-uid',
+      submissionUid: 'async-test-submission-uid',
+      status: 'success',
+      message: 'Async test completed successfully',
+      stdout: 'Async test output'
+    };
+
+    // Create a mock async callback that returns a promise
+    const mockAsyncCallback = vi.fn().mockImplementation(async (payload) => {
+      // Simulate async operation
+      await new Promise(resolve => setTimeout(resolve, 10));
+      return payload;
+    });
+
+    // Set the async callback
+    setOnResultReadyCallback(mockAsyncCallback);
+
+    // Create and dispatch a onResultReady message event with the mock instance context and result
+    const event = new MessageEvent('message', {
+      data: { 
+        service: 'pumproom', 
+        type: 'onResultReady',
+        payload: {
+          instanceContext: mockInstanceContext,
+          result: mockResult
+        }
+      },
+      origin: 'https://pumproom.tech',
+      source: window
+    });
+
+    // Simulate handling the message
+    handleResultReadyMessage(event);
+
+    // Verify the callback was called with the correct payload
+    expect(mockAsyncCallback).toHaveBeenCalledWith({
+      instanceContext: mockInstanceContext,
+      result: mockResult
     });
 
     // Wait for any pending promises to resolve

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -27,7 +27,11 @@ describe('environment helpers', () => {
     const postSpy = vi.spyOn(window, 'postMessage');
     setEnvironmentListener();
     const event = new MessageEvent('message', {
-      data: { service: 'pumproom', type: 'getEnvironment' },
+      data: {
+        service: 'pumproom',
+        type: 'getEnvironment',
+        payload: { instanceContext: { instanceUid: 'test', repoName: '', taskName: '', realm: '', tags: '' } }
+      },
       origin: 'https://pumproom.tech',
       source: window
     });
@@ -64,10 +68,10 @@ describe('environment helpers', () => {
 
     // Create and dispatch a getEnvironment message event with the mock instance context
     const event = new MessageEvent('message', {
-      data: { 
-        service: 'pumproom', 
+      data: {
+        service: 'pumproom',
         type: 'getEnvironment',
-        payload: mockInstanceContext
+        payload: { instanceContext: mockInstanceContext }
       },
       origin: 'https://pumproom.tech',
       source: window
@@ -75,7 +79,7 @@ describe('environment helpers', () => {
     window.dispatchEvent(event);
 
     // Verify the callback was called with the correct instance context
-    expect(mockCallback).toHaveBeenCalledWith(mockInstanceContext);
+    expect(mockCallback).toHaveBeenCalledWith({ instanceContext: mockInstanceContext });
   });
 
   it('executes asynchronous onInitCallback when getEnvironment message is received', async () => {
@@ -103,10 +107,10 @@ describe('environment helpers', () => {
 
     // Create and dispatch a getEnvironment message event with the mock instance context
     const event = new MessageEvent('message', {
-      data: { 
-        service: 'pumproom', 
+      data: {
+        service: 'pumproom',
         type: 'getEnvironment',
-        payload: mockInstanceContext
+        payload: { instanceContext: mockInstanceContext }
       },
       origin: 'https://pumproom.tech',
       source: window
@@ -114,7 +118,7 @@ describe('environment helpers', () => {
     window.dispatchEvent(event);
 
     // Verify the callback was called with the correct instance context
-    expect(mockAsyncCallback).toHaveBeenCalledWith(mockInstanceContext);
+    expect(mockAsyncCallback).toHaveBeenCalledWith({ instanceContext: mockInstanceContext });
 
     // Wait for any pending promises to resolve
     await new Promise(resolve => setTimeout(resolve, 20));

--- a/tests/instance.test.ts
+++ b/tests/instance.test.ts
@@ -128,10 +128,10 @@ describe('instance module', () => {
 
     // Create and dispatch a getEnvironment message event
     const event = new MessageEvent('message', {
-      data: { 
-        service: 'pumproom', 
+      data: {
+        service: 'pumproom',
         type: 'getEnvironment',
-        payload: instanceContext
+        payload: { instanceContext }
       },
       origin: 'https://pumproom.tech',
       source: window

--- a/tests/site.test.ts
+++ b/tests/site.test.ts
@@ -1,0 +1,26 @@
+import {describe, it, expect, vi} from 'vitest';
+
+const addPlugin = vi.fn();
+const highlightAll = vi.fn();
+const pluginCtor = vi.fn().mockReturnValue({name: 'plugin'});
+
+vi.mock('highlight.js', () => ({
+  default: { addPlugin, highlightAll }
+}));
+vi.mock('highlightjs-copy', () => ({
+  default: pluginCtor
+}));
+vi.mock('./src/styles/bootstrap.scss', () => ({}), { virtual: true });
+vi.mock('bootstrap/dist/js/bootstrap.bundle.min.js', () => ({}), { virtual: true });
+vi.mock('highlight.js/styles/github.css', () => ({}), { virtual: true });
+vi.mock('highlightjs-copy/dist/highlightjs-copy.min.css', () => ({}), { virtual: true });
+
+describe('site script', () => {
+  it('initializes highlight.js on DOMContentLoaded', async () => {
+    await import('../site.ts');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    expect(pluginCtor).toHaveBeenCalledWith({ autohide: false });
+    expect(addPlugin).toHaveBeenCalledWith({ name: 'plugin' });
+    expect(highlightAll).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- fix callbacks tests to import helpers directly
- update environment tests to send valid payload and match callback args
- adjust instance test to wrap instanceContext inside payload
- document `EnvironmentData` in types

## Testing
- `npm test --silent`
- `npm run docs --silent`


------
https://chatgpt.com/codex/tasks/task_e_686d31b66eb48324886b67f639fff4ca