### PR TITLE
Categorize state API docs

### DIFF
--- a/example/main.ts
+++ b/example/main.ts
@@ -122,15 +122,16 @@ document.addEventListener('DOMContentLoaded', async () => {
 // Helper function to load states
 async function loadStates() {
     try {
-        const result = await PumpRoomSdk.fetchStates(['checkbox1State', 'checkbox2State', 'textInputState']);
-        console.log('Fetched states:', result);
-
-        // Try to update UI with fetched states
-        if (Array.isArray(result.states)) {
-            updateUIFromStates(result.states);
-        } else {
-            console.error('Invalid state format received:', result);
-        }
+        // Use the callback parameter to update UI immediately with cached states
+        // and then again with states fetched from the server
+        const result = await PumpRoomSdk.fetchStates(
+            ['checkbox1State', 'checkbox2State', 'textInputState'],
+            (states) => {
+                console.log('Received states via callback:', states);
+                updateUIFromStates(states);
+            }
+        );
+        console.log('Fetched states (final result):', result);
     } catch (error) {
         console.error(`Error fetching states: ${error instanceof Error ? error.message : String(error)}`);
     }
@@ -140,7 +141,7 @@ async function loadStates() {
 function updateUIFromStates(states: Array<{
     name: string,
     value: boolean | number | string | null
-}>, retryCount = 0) {
+}>) {
     // Get UI elements
     console.log('Updating UI from states...');
     const checkbox1 = document.getElementById('checkbox1') as HTMLInputElement;

--- a/example/main.ts
+++ b/example/main.ts
@@ -21,7 +21,7 @@ PumpRoomSdk.init({
 
 PumpRoomSdk.setOnInitCallback(async (data) => {
     console.log('[CB] Instance initialized:', data);
-    console.log('[CB] All instances', PumpRoomSdk.getInstances())
+    console.log('[CB] All instances', PumpRoomSdk.getTaskInstances())
 });
 
 PumpRoomSdk.setOnTaskLoadedCallback(async (data) => {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build-lib": "vite build -c vite.config.lib.ts && tsc -p tsconfig.build.json --emitDeclarationOnly",
     "build-site": "bun run docs && vite build -c vite.config.site.ts",
     "dev": "vite build -c vite.config.lib.ts && bun run docs && vite -c vite.config.site.ts",
+    "preview": "vite preview -c vite.config.site.ts",
     "docs": "typedoc --options typedoc.json",
     "test": "vitest run --coverage",
     "postversion": "git push && git push --tags"

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "vite build -c vite.config.lib.ts && tsc -p tsconfig.build.json --emitDeclarationOnly && npm run docs && vite build -c vite.config.site.ts",
+    "build": "vite build -c vite.config.lib.ts && tsc -p tsconfig.build.json --emitDeclarationOnly && bun run docs && vite build -c vite.config.site.ts",
     "build-lib": "vite build -c vite.config.lib.ts && tsc -p tsconfig.build.json --emitDeclarationOnly",
-    "build-site": "npm run docs && vite build -c vite.config.site.ts",
-    "dev": "vite build -c vite.config.lib.ts && npm run docs && vite -c vite.config.site.ts",
-    "docs": "typedoc --options typedoc.json --skipErrorChecking",
+    "build-site": "bun run docs && vite build -c vite.config.site.ts",
+    "dev": "vite build -c vite.config.lib.ts && bun run docs && vite -c vite.config.site.ts",
+    "docs": "typedoc --options typedoc.json",
     "test": "vitest run --coverage",
     "postversion": "git push && git push --tags"
   },
@@ -41,7 +41,7 @@
   "sideEffects": true,
   "engines": {
     "node": ">=20",
-    "npm": ">=9"
+    "bun": ">=1.1.8"
   },
   "license": "UNLICENSED",
   "author": {

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -128,6 +128,7 @@ export class ApiClient {
      * @returns Promise resolving to the fetched states
      * @throws Error if the request fails
      *
+     * @category Experimental
      * @example
      * ```typescript
      * try {
@@ -170,6 +171,7 @@ export class ApiClient {
      * @returns Promise resolving to the result of the operation
      * @throws Error if the request fails
      *
+     * @category Experimental
      * @example
      * ```typescript
      * try {

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -8,6 +8,7 @@ import {
     GetStatesResponse,
     SetStatesResponse,
 } from './types/index.ts';
+import {getCurrentNormalizedUrl} from "./utils.js";
 import {AUTH_URL, VERIFY_URL, GET_STATES_URL, SET_STATES_URL} from './constants.ts';
 import {getVersion} from './version.ts';
 
@@ -98,7 +99,7 @@ export class ApiClient {
             lms: options.lms,
             profile: options.profile,
             realm: realm,
-            url: typeof window !== 'undefined' ? window.location.href : null,
+            url: getCurrentNormalizedUrl(),
             sdk_version: getVersion(),
         };
 
@@ -148,7 +149,7 @@ export class ApiClient {
             },
             body: JSON.stringify({
                 user: user,
-                url: typeof window !== 'undefined' ? window.location.href : null,
+                url: getCurrentNormalizedUrl(),
                 state_names: stateNames,
                 sdk_version: getVersion()
             })
@@ -194,7 +195,7 @@ export class ApiClient {
             },
             body: JSON.stringify({
                 user: user,
-                url: typeof window !== 'undefined' ? window.location.href : null,
+                url: getCurrentNormalizedUrl(),
                 states: states,
                 sdk_version: getVersion()
             })

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -128,7 +128,7 @@ export class ApiClient {
      * @returns Promise resolving to the fetched states
      * @throws Error if the request fails
      *
-     * @category Experimental
+     * @experimental
      * @example
      * ```typescript
      * try {
@@ -171,7 +171,7 @@ export class ApiClient {
      * @returns Promise resolving to the result of the operation
      * @throws Error if the request fails
      *
-     * @category Experimental
+     * @experimental
      * @example
      * ```typescript
      * try {

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -5,8 +5,7 @@ import {
     PumpRoomUser,
     AuthenticateOptions,
     State,
-    GetStatesResponse,
-    SetStatesResponse,
+    StatesResponse,
 } from './types/index.ts';
 import {getCurrentNormalizedUrl} from "./utils.js";
 import {AUTH_URL, VERIFY_URL, GET_STATES_URL, SET_STATES_URL} from './constants.ts';
@@ -140,7 +139,7 @@ export class ApiClient {
      * }
      * ```
      */
-    async fetchStates(stateNames: string[], user: PumpRoomUser): Promise<GetStatesResponse> {
+    async fetchStates(stateNames: string[], user: PumpRoomUser): Promise<StatesResponse> {
         const response = await fetch(GET_STATES_URL, {
             method: 'POST',
             headers: {
@@ -159,7 +158,7 @@ export class ApiClient {
             throw new Error(`Request error: ${response.status} ${response.statusText}`);
         }
 
-        return await response.json() as GetStatesResponse;
+        return await response.json() as StatesResponse;
     }
 
     /**
@@ -186,7 +185,7 @@ export class ApiClient {
      * }
      * ```
      */
-    async storeStates(states: State[], user: PumpRoomUser): Promise<SetStatesResponse> {
+    async storeStates(states: State[], user: PumpRoomUser): Promise<StatesResponse> {
         const response = await fetch(SET_STATES_URL, {
             method: 'POST',
             headers: {
@@ -205,7 +204,7 @@ export class ApiClient {
             throw new Error(`Request error: ${response.status} ${response.statusText}`);
         }
 
-        return await response.json() as SetStatesResponse;
+        return await response.json() as StatesResponse;
     }
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -5,6 +5,7 @@
  * It provides functions for authenticating users and setting user information.
  *
  * @module Authentication
+ * @category Authentication
  */
 import type {PumpRoomUser, AuthenticateOptions, LMSProfileInput} from './types/index.ts';
 import type {SetPumpRoomUserMessage} from './types/messages.ts';
@@ -91,6 +92,8 @@ async function verifyCachedUser(user: PumpRoomUser): Promise<boolean> {
  *
  * @param options - Authentication options containing LMS and/or profile data
  * @returns Promise resolving to the authenticated user or null if authentication failed
+ * @category Authentication
+ * @public
  * @example
  * ```typescript
  * import { authenticate } from 'pumproom-sdk';
@@ -159,6 +162,8 @@ export async function authenticate({lms, profile}: AuthenticateOptions = {}): Pr
  *
  * @param user - The user object containing uid and token
  * @returns Promise resolving to the verified user or null if verification failed
+ * @category Authentication
+ * @public
  * @example
  * ```typescript
  * import { setUser } from 'pumproom-sdk';

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -149,8 +149,6 @@ export async function authenticate({lms, profile}: AuthenticateOptions = {}): Pr
 
     setCurrentUser(currentUser);
 
-    document.dispatchEvent(new CustomEvent('itAuthenticationCompleted', {detail: currentUser}));
-
     return currentUser;
 }
 
@@ -211,7 +209,6 @@ export async function setUser(user: Omit<PumpRoomUser, 'is_admin'>): Promise<Pum
         registerAutoListener();
     }
 
-    document.dispatchEvent(new CustomEvent('itAuthenticationCompleted', {detail: verified}));
     return verified;
 }
 

--- a/src/callbacks.ts
+++ b/src/callbacks.ts
@@ -33,6 +33,8 @@ import type {
  * The callback can be either synchronous or asynchronous (async function).
  *
  * @param callback - The callback function to execute on initialization (can be async)
+ * @category Callbacks
+ * @public
  * @example
  * ```typescript
  * // Set a synchronous callback to be executed on initialization
@@ -66,6 +68,8 @@ export function setOnInitCallback(callback: OnInitCallback): void {
  * asynchronous (async function).
  *
  * @param callback - The callback function to execute when a task is loaded (can be async)
+ * @category Callbacks
+ * @public
  * @example
  * ```typescript
  * // Set a synchronous callback to be executed when a task is loaded
@@ -98,6 +102,8 @@ export function setOnTaskLoadedCallback(callback: OnTaskLoadedCallback): void {
  * asynchronous (async function).
  *
  * @param callback - The callback function to execute when a task is submitted (can be async)
+ * @category Callbacks
+ * @public
  * @example
  * ```typescript
  * // Set a synchronous callback to be executed when a task is submitted
@@ -130,6 +136,8 @@ export function setOnTaskSubmittedCallback(callback: OnTaskSubmittedCallback): v
  * asynchronous (async function).
  *
  * @param callback - The callback function to execute when a result is ready (can be async)
+ * @category Callbacks
+ * @public
  * @example
  * ```typescript
  * // Set a synchronous callback to be executed when a result is ready

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,3 +61,10 @@ export const PUMPROOM_DOMAINS = [
  * @public
  */
 export const USER_STORAGE_KEY = 'pumproomUser'
+
+/**
+ * Prefix for localStorage keys to avoid conflicts with other applications when storing states
+ * 
+ * @experimental
+ */
+export const STORAGE_PREFIX = 'pumproomState:'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,32 +7,46 @@
  * @module Constants
  */
 
-/** Base URL for the PumpRoom API */
+/**
+ * Base URL for the PumpRoom API
+ *
+ * @public
+ */
 export const API_BASE_URL = 'https://pumproom-api.inzhenerka-cloud.com';
 
-/** URL for the authentication endpoint */
+/**
+ * URL for the authentication endpoint
+ *
+ * @public
+ */
 export const AUTH_URL = `${API_BASE_URL}/auth/authenticate`;
 
-/** URL for the token verification endpoint */
+/**
+ * URL for the token verification endpoint
+ *
+ * @public
+ */
 export const VERIFY_URL = `${API_BASE_URL}/auth/verify_token`;
 
 /**
  * URL to load states from backend
  *
- * @category Experimental
+ * @experimental
  */
 export const GET_STATES_URL = `${API_BASE_URL}/tracker/get_states`;
 
 /**
  * URL to store states on backend
  *
- * @category Experimental
+ * @experimental
  */
 export const SET_STATES_URL = `${API_BASE_URL}/tracker/set_states`;
 
-/** 
+/**
  * List of domains that are considered PumpRoom domains
  * Used to identify PumpRoom iframes
+ *
+ * @public
  */
 export const PUMPROOM_DOMAINS = [
     'https://pumproom.',
@@ -41,5 +55,9 @@ export const PUMPROOM_DOMAINS = [
     'https://ide.code.winbd.ru'
 ] as const;
 
-/** Key used for storing user data in localStorage */
+/**
+ * Key used for storing user data in localStorage
+ *
+ * @public
+ */
 export const USER_STORAGE_KEY = 'pumproomUser'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,10 +16,18 @@ export const AUTH_URL = `${API_BASE_URL}/auth/authenticate`;
 /** URL for the token verification endpoint */
 export const VERIFY_URL = `${API_BASE_URL}/auth/verify_token`;
 
-/** URL to load states from backend */
+/**
+ * URL to load states from backend
+ *
+ * @category Experimental
+ */
 export const GET_STATES_URL = `${API_BASE_URL}/tracker/get_states`;
 
-/** URL to store states on backend */
+/**
+ * URL to store states on backend
+ *
+ * @category Experimental
+ */
 export const SET_STATES_URL = `${API_BASE_URL}/tracker/set_states`;
 
 /** 

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -10,7 +10,7 @@
 import {getPumpRoomEventMessage} from './messaging.ts';
 import {getVersion} from './version.ts';
 import type {SetEnvironmentMessage} from './types/messages.js';
-import {registerInstance} from './instance.ts';
+import {registerTaskInstance} from './instance.ts';
 import {executeOnInitCallback} from './callbacks.ts';
 
 // The setOnInitCallback function has been moved to callbacks.ts
@@ -73,7 +73,7 @@ function handleEnvironmentMessage(event: MessageEvent): void {
     const data = getPumpRoomEventMessage(event, 'getEnvironment');
     if (!data) return
     // Register the instance using the instance module
-    registerInstance(data.payload.instanceContext);
+    registerTaskInstance(data.payload.instanceContext);
 
     if (event.source) {
         sendEnvironment(event.source as Window, event.origin);

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -12,6 +12,7 @@ import {getVersion} from './version.ts';
 import type {SetEnvironmentMessage} from './types/messages.js';
 import {registerTaskInstance} from './instance.ts';
 import {executeOnInitCallback} from './callbacks.ts';
+import {getCurrentNormalizedUrl} from './utils.ts';
 
 // The setOnInitCallback function has been moved to callbacks.ts
 
@@ -32,8 +33,12 @@ export interface PumpRoomEnvironment {
  * @internal
  */
 function buildEnvironment(): PumpRoomEnvironment {
+    const pageURL = getCurrentNormalizedUrl();
+    if (!pageURL) {
+        throw new Error('Unable to determine current page URL');
+    }
     return {
-        pageURL: window.location.href,
+        pageURL: pageURL,
         sdkVersion: getVersion(),
     };
 }

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -277,7 +277,7 @@ export function getApiClientInstance(): ApiClient {
  * @param stateNames - Array of state names to register
  * @throws Error if stateNames is not an array
  *
- * @category Experimental
+ * @experimental
  * @example
  * ```typescript
  * registerStates(['userPreferences', 'lastVisitedPage']);
@@ -300,7 +300,7 @@ export function registerStates(stateNames: string[]): void {
  * 
  * @returns Array of registered state names
  *
- * @category Experimental
+ * @experimental
  * @example
  * ```typescript
  * const states = getRegisteredStates();
@@ -316,7 +316,7 @@ export function getRegisteredStates(): string[] {
  * 
  * This function is primarily used for testing purposes.
  *
- * @category Experimental
+ * @experimental
  * @internal
  */
 export function resetRegisteredStates(): void {

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -276,7 +276,8 @@ export function getApiClientInstance(): ApiClient {
  * 
  * @param stateNames - Array of state names to register
  * @throws Error if stateNames is not an array
- * 
+ *
+ * @category Experimental
  * @example
  * ```typescript
  * registerStates(['userPreferences', 'lastVisitedPage']);
@@ -298,7 +299,8 @@ export function registerStates(stateNames: string[]): void {
  * Gets the list of registered state names
  * 
  * @returns Array of registered state names
- * 
+ *
+ * @category Experimental
  * @example
  * ```typescript
  * const states = getRegisteredStates();
@@ -313,7 +315,8 @@ export function getRegisteredStates(): string[] {
  * Resets the list of registered state names
  * 
  * This function is primarily used for testing purposes.
- * 
+ *
+ * @category Experimental
  * @internal
  */
 export function resetRegisteredStates(): void {

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -73,6 +73,8 @@ export function setCurrentUser(user: PumpRoomUser | null): void {
  *
  * @returns The current user or null if not authenticated
  *
+ * @category Authentication
+ * @public
  * @example
  * ```typescript
  * const user = getCurrentUser();
@@ -153,7 +155,7 @@ export function setFullscreenInitialized(): void {
  * registerInstance({ instanceUid: '1', repoName: 'repo', taskName: 'task', realm: 'test', tags: undefined });
  * ```
  */
-export function registerInstance(instanceContext: InstanceContext): void {
+export function registerTaskInstance(instanceContext: InstanceContext): void {
     if (instanceContext && instanceContext.instanceUid) {
         instanceRegistry[instanceContext.instanceUid] = instanceContext;
     }
@@ -170,7 +172,7 @@ export function registerInstance(instanceContext: InstanceContext): void {
  * console.log(Object.keys(instances));
  * ```
  */
-export function getInstances(): Record<string, InstanceContext> {
+export function getTaskInstances(): Record<string, InstanceContext> {
     return {...instanceRegistry};
 }
 
@@ -300,6 +302,7 @@ export function registerStates(stateNames: string[]): void {
  * 
  * @returns Array of registered state names
  *
+ * @category States
  * @experimental
  * @example
  * ```typescript

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,18 @@
 /**
- * PumpRoom SDK - Main entry point
+ * PumpRoom SDK
  *
  * This module provides the main functionality for integrating with the PumpRoom platform.
  * It handles initialization, authentication, and user management.
- *
+ * @categoryDescription Initialization
+ *  Functions for initializing and configuring the SDK. They must be called before using any other SDK functionality.
+ * @categoryDescription Authentication
+ *  Functions for user authentication and management, including setting and retrieving user information.
+ * @categoryDescription Callbacks
+ *  Functions for setting up event handlers and callback functions that respond to SDK lifecycle events.
+ * @categoryDescription Tasks
+ *  Functions for working with task instances and retrieving task-related information.
+ * @categoryDescription States
+ *  [Experimental] Functions for managing persistent state data, including storing, retrieving, and clearing application states.
  * @module PumpRoomSDK
  */
 
@@ -19,7 +28,7 @@ import {initApiClient} from './api-client.ts';
 export {getCurrentUser} from './globals.ts';
 export {authenticate, setUser} from './auth.ts';
 export {getVersion} from './version.ts';
-export {getInstances} from './instance.ts';
+export {getTaskInstances} from './instance.ts';
 export {
     setOnInitCallback, 
     setOnTaskLoadedCallback, 
@@ -66,6 +75,8 @@ console.debug('PumpRoom SDK v' + getVersion() + ' loaded');
  * It sets up the API client, event listeners, and iframe configuration.
  *
  * @param cfg - The SDK configuration object
+ * @category Initialization
+ * @public
  * @example
  * ```typescript
  * import { init } from 'pumproom-sdk';

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,8 +62,8 @@ export type {
     State,
     StateOutput,
     StateDataType,
-    GetStatesResponse,
-    SetStatesResponse,
+    StatesResponse,
+    StatesCallback,
 } from './types/index.ts';
 
 console.debug('PumpRoom SDK v' + getVersion() + ' loaded');

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -6,7 +6,7 @@
  *
  * @module Instance
  */
-import {registerInstance as registerInstanceGlobal, getInstances as getInstancesGlobal} from './globals.ts';
+import {registerTaskInstance as registerInstanceGlobal, getTaskInstances as getInstancesGlobal} from './globals.ts';
 import type {InstanceContext} from './types/index.ts';
 
 /**
@@ -20,7 +20,7 @@ import type {InstanceContext} from './types/index.ts';
  * registerInstance({ instanceUid: '1', repoName: 'repo', taskName: 'task', realm: 'test', tags: undefined });
  * ```
  */
-export function registerInstance(instanceContext: InstanceContext): void {
+export function registerTaskInstance(instanceContext: InstanceContext): void {
     registerInstanceGlobal(instanceContext);
 }
 
@@ -28,13 +28,14 @@ export function registerInstance(instanceContext: InstanceContext): void {
  * Gets all registered instances
  *
  * @returns A record mapping instance UIDs to their contexts
- *
+ * @category Tasks
+ * @public
  * @example
  * ```typescript
  * const instances = getInstances();
  * console.log(Object.keys(instances));
  * ```
  */
-export function getInstances(): Record<string, InstanceContext> {
+export function getTaskInstances(): Record<string, InstanceContext> {
     return getInstancesGlobal();
 }

--- a/src/states.ts
+++ b/src/states.ts
@@ -5,7 +5,7 @@
  * It allows registering, fetching, storing, and clearing states.
  *
  * @module States
- * @category Experimental
+ * @experimental
  */
 
 import {getCurrentUser, registerStates, getRegisteredStates, resetRegisteredStates} from './globals.ts';
@@ -21,7 +21,7 @@ import type {State, GetStatesResponse, SetStatesResponse} from './types/index.ts
  * @returns Promise resolving to the fetched states
  * @throws Error if stateNames is not a non-empty array or if user is not authenticated
  *
- * @category Experimental
+ * @experimental
  * @example
  * ```typescript
  * // Using async/await
@@ -73,7 +73,7 @@ export async function fetchStates(stateNames: string[]): Promise<GetStatesRespon
  * @returns Promise resolving to the result of the operation
  * @throws Error if states is not an array or if user is not authenticated
  *
- * @category Experimental
+ * @experimental
  * @example
  * ```typescript
  * // Using async/await
@@ -129,7 +129,7 @@ export async function storeStates(states: State[]): Promise<SetStatesResponse> {
  * @returns Promise resolving to the result of the operation
  * @throws Error if stateNames is not a non-empty array
  *
- * @category Experimental
+ * @experimental
  * @example
  * ```typescript
  * // Using async/await

--- a/src/states.ts
+++ b/src/states.ts
@@ -5,6 +5,7 @@
  * It allows registering, fetching, storing, and clearing states.
  *
  * @module States
+ * @category States
  * @experimental
  */
 
@@ -21,6 +22,7 @@ import type {State, GetStatesResponse, SetStatesResponse} from './types/index.ts
  * @returns Promise resolving to the fetched states
  * @throws Error if stateNames is not a non-empty array or if user is not authenticated
  *
+ * @category States
  * @experimental
  * @example
  * ```typescript
@@ -73,6 +75,7 @@ export async function fetchStates(stateNames: string[]): Promise<GetStatesRespon
  * @returns Promise resolving to the result of the operation
  * @throws Error if states is not an array or if user is not authenticated
  *
+ * @category States
  * @experimental
  * @example
  * ```typescript
@@ -129,6 +132,7 @@ export async function storeStates(states: State[]): Promise<SetStatesResponse> {
  * @returns Promise resolving to the result of the operation
  * @throws Error if stateNames is not a non-empty array
  *
+ * @category States
  * @experimental
  * @example
  * ```typescript
@@ -167,6 +171,8 @@ export async function clearStates(stateNames: string[]): Promise<SetStatesRespon
  *
  * @returns Array of registered state names
  *
+ * @category States
+ * @experimental
  * @example
  * ```typescript
  * const states = getRegisteredStates();

--- a/src/states.ts
+++ b/src/states.ts
@@ -5,6 +5,7 @@
  * It allows registering, fetching, storing, and clearing states.
  *
  * @module States
+ * @category Experimental
  */
 
 import {getCurrentUser, registerStates, getRegisteredStates, resetRegisteredStates} from './globals.ts';
@@ -20,6 +21,7 @@ import type {State, GetStatesResponse, SetStatesResponse} from './types/index.ts
  * @returns Promise resolving to the fetched states
  * @throws Error if stateNames is not a non-empty array or if user is not authenticated
  *
+ * @category Experimental
  * @example
  * ```typescript
  * // Using async/await
@@ -71,6 +73,7 @@ export async function fetchStates(stateNames: string[]): Promise<GetStatesRespon
  * @returns Promise resolving to the result of the operation
  * @throws Error if states is not an array or if user is not authenticated
  *
+ * @category Experimental
  * @example
  * ```typescript
  * // Using async/await
@@ -126,6 +129,7 @@ export async function storeStates(states: State[]): Promise<SetStatesResponse> {
  * @returns Promise resolving to the result of the operation
  * @throws Error if stateNames is not a non-empty array
  *
+ * @category Experimental
  * @example
  * ```typescript
  * // Using async/await

--- a/src/states.ts
+++ b/src/states.ts
@@ -80,7 +80,7 @@ export async function fetchStates(stateNames: string[], callback?: StatesCallbac
     // If we have cached states and a callback, call the callback with the cached states
     if (cachedStates.length > 0) {
         if (callback) {
-            callback(cachedStates);
+            callback({states: cachedStates});
         }
     }
 
@@ -95,7 +95,7 @@ export async function fetchStates(stateNames: string[], callback?: StatesCallbac
 
     // If we have a callback, call it with the fetched states
     if (callback) {
-        callback(response.states);
+        callback(response);
     }
 
     return response;

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,19 +1,23 @@
 /**
  * Storage module for PumpRoom SDK
- * 
+ *
  * This module provides utilities for storing and retrieving data
  * from the browser's localStorage, with error handling for environments
  * where localStorage is not available or when parsing fails.
- * 
+ *
  * @module Storage
  */
 
+import {getCurrentNormalizedUrl} from "./utils.js";
+import {STORAGE_PREFIX} from './constants.ts';
+import type {StateOutput} from './types/index.ts';
+
 /**
  * Retrieves data from localStorage
- * 
+ *
  * This function attempts to retrieve and parse JSON data from localStorage.
  * It handles cases where localStorage is not available or when parsing fails.
- * 
+ *
  * @param key - The key to retrieve data for
  * @returns The parsed data object or null if retrieval or parsing failed
  *
@@ -35,10 +39,10 @@ export function retrieveData(key: string): Record<any, any> | null {
 
 /**
  * Stores data in localStorage
- * 
+ *
  * This function attempts to stringify and store data in localStorage.
  * It handles cases where localStorage is not available or when stringification fails.
- * 
+ *
  * @param key - The key to store data under
  * @param data - The data object to store
  *
@@ -54,4 +58,69 @@ export function storeData(key: string, data: Record<any, any>): void {
     } catch (err) {
         console.error('Cache save error', err);
     }
+}
+
+/**
+ * Generates a unique key for a state in localStorage
+ *
+ * @param stateName - Name of the state
+ * @param userId - User ID
+ * @returns Unique key for the state
+ *
+ * @experimental
+ */
+export function generateStateKey(stateName: string, userId: string): string {
+    const pageUrl = getCurrentNormalizedUrl();
+    if (!pageUrl) {
+        throw new Error('Unable to determine current page URL');
+    }
+    return `${STORAGE_PREFIX}:${pageUrl}:${stateName}:${userId}`;
+}
+
+/**
+ * Saves states to localStorage
+ *
+ * @param states - Array of states to save
+ * @param userId - User ID
+ *
+ * @experimental
+ */
+export function saveStatesToLocalStorage(states: StateOutput[], userId: string): void {
+    try {
+        states.forEach(state => {
+            const key = generateStateKey(state.name, userId);
+            localStorage.setItem(key, JSON.stringify(state));
+        });
+    } catch (error) {
+        console.warn('Failed to save states to localStorage:', error);
+    }
+}
+
+/**
+ * Retrieves states from localStorage
+ *
+ * @param stateNames - Array of state names to retrieve
+ * @param userId - User ID
+ * @returns Array of states retrieved from localStorage
+ *
+ * @experimental
+ */
+export function getStatesFromLocalStorage(stateNames: string[], userId: string): StateOutput[] {
+    const states: StateOutput[] = [];
+
+    try {
+        stateNames.forEach(stateName => {
+            const key = generateStateKey(stateName, userId);
+            const stateJson = localStorage.getItem(key);
+
+            if (stateJson) {
+                const state = JSON.parse(stateJson) as StateOutput;
+                states.push(state);
+            }
+        });
+    } catch (error) {
+        console.warn('Failed to retrieve states from localStorage:', error);
+    }
+
+    return states;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,7 +24,7 @@ export type IdentityProviderType = 'tilda' | 'telegram';
  * Status of a task submission
  *
  * @public
- * @category Submission
+ * @category Callbacks
  */
 export type SubmissionStatus = 'success' | 'fail' | 'internal_error';
 
@@ -225,7 +225,7 @@ export interface VerifyTokenResult {
  * to the init function to configure the SDK.
  *
  * @public
- * @category Configuration
+ * @category Initialization
  */
 export interface PumpRoomConfig {
     /** API key for authenticating with the PumpRoom API */
@@ -271,7 +271,7 @@ export interface InternalConfig {
  * containing identification and metadata used for instance registration and management.
  *
  * @public
- * @category Instance
+ * @category Callbacks
  */
 export interface InstanceContext {
     /** Unique identifier for the instance */
@@ -336,7 +336,7 @@ export interface FullscreenParameters {
  * Status of a task loading process
  *
  * @public
- * @category Tasks
+ * @category Callbacks
  */
 export type TaskStatus = 'loading' | 'ready' | 'error';
 
@@ -344,7 +344,7 @@ export type TaskStatus = 'loading' | 'ready' | 'error';
  * Detailed information about a task
  *
  * @public
- * @category Tasks
+ * @category Callbacks
  */
 export interface TaskDetails {
     /** Unique identifier of the task */
@@ -357,7 +357,7 @@ export interface TaskDetails {
  * Result of a task submission
  *
  * @public
- * @category Submission
+ * @category Callbacks
  */
 export interface SubmissionResult {
     /** Unique identifier of the task */
@@ -376,7 +376,7 @@ export interface SubmissionResult {
  * Data provided to callbacks after the SDK receives environment information
  *
  * @public
- * @category Environment
+ * @category Callbacks
  */
 export interface EnvironmentData {
     /** Context information about the current instance */
@@ -387,7 +387,7 @@ export interface EnvironmentData {
  * Data provided to callbacks when a task is loaded
  *
  * @public
- * @category Tasks
+ * @category Callbacks
  */
 export interface LoadedTaskData {
     /** Context information about the current instance */
@@ -400,7 +400,7 @@ export interface LoadedTaskData {
  * Data provided to callbacks when a result is ready
  *
  * @public
- * @category Results
+ * @category Callbacks
  */
 export interface ResultData {
     /** Context information about the current instance */

--- a/src/types/states.ts
+++ b/src/types/states.ts
@@ -4,14 +4,14 @@
  * This file contains type definitions for the States module.
  * 
  * @module Types/States
- * @category States
+ * @category Experimental
  */
 
 /**
  * Enum for state data types
  * 
  * @public
- * @category States
+ * @category Experimental
  */
 export enum StateDataType {
     /** Boolean value */
@@ -28,7 +28,7 @@ export enum StateDataType {
  * Interface representing a state input object
  * 
  * @public
- * @category States
+ * @category Experimental
  */
 export interface State {
     /** Name of the state */
@@ -41,7 +41,7 @@ export interface State {
  * Interface representing a state output object
  * 
  * @public
- * @category States
+ * @category Experimental
  */
 export interface StateOutput extends State {
     /** Data type of the state value */
@@ -52,7 +52,7 @@ export interface StateOutput extends State {
  * Response from the get_states API endpoint
  * 
  * @public
- * @category States
+ * @category Experimental
  */
 export interface GetStatesResponse {
     /** Status of the operation */
@@ -67,7 +67,7 @@ export interface GetStatesResponse {
  * Response from the set_states API endpoint
  * 
  * @public
- * @category States
+ * @category Experimental
  */
 export interface SetStatesResponse {
     /** Status of the operation */

--- a/src/types/states.ts
+++ b/src/types/states.ts
@@ -60,10 +60,6 @@ export interface StateOutput extends State {
  * @experimental
  */
 export interface GetStatesResponse {
-    /** Status of the operation */
-    status: 'success' | 'error';
-    /** Optional error message */
-    error?: string;
     /** Array of state objects */
     states: StateOutput[];
 }
@@ -76,8 +72,6 @@ export interface GetStatesResponse {
  * @experimental
  */
 export interface SetStatesResponse {
-    /** Status of the operation */
-    status: 'success' | 'error';
     /** Optional error message */
     error?: string;
 }

--- a/src/types/states.ts
+++ b/src/types/states.ts
@@ -71,4 +71,4 @@ export interface StatesResponse {
  * @category States
  * @experimental
  */
-export type StatesCallback = (states: StateOutput[]) => void;
+export type StatesCallback = (states: StatesResponse) => void;

--- a/src/types/states.ts
+++ b/src/types/states.ts
@@ -4,14 +4,16 @@
  * This file contains type definitions for the States module.
  * 
  * @module Types/States
- * @category Experimental
+ * @category States
+ * @experimental
  */
 
 /**
  * Enum for state data types
  * 
  * @public
- * @category Experimental
+ * @category States
+ * @experimental
  */
 export enum StateDataType {
     /** Boolean value */
@@ -28,7 +30,8 @@ export enum StateDataType {
  * Interface representing a state input object
  * 
  * @public
- * @category Experimental
+ * @category States
+ * @experimental
  */
 export interface State {
     /** Name of the state */
@@ -41,7 +44,8 @@ export interface State {
  * Interface representing a state output object
  * 
  * @public
- * @category Experimental
+ * @category States
+ * @experimental
  */
 export interface StateOutput extends State {
     /** Data type of the state value */
@@ -52,7 +56,8 @@ export interface StateOutput extends State {
  * Response from the get_states API endpoint
  * 
  * @public
- * @category Experimental
+ * @category States
+ * @experimental
  */
 export interface GetStatesResponse {
     /** Status of the operation */
@@ -67,7 +72,8 @@ export interface GetStatesResponse {
  * Response from the set_states API endpoint
  * 
  * @public
- * @category Experimental
+ * @category States
+ * @experimental
  */
 export interface SetStatesResponse {
     /** Status of the operation */

--- a/src/types/states.ts
+++ b/src/types/states.ts
@@ -53,25 +53,22 @@ export interface StateOutput extends State {
 }
 
 /**
- * Response from the get_states API endpoint
+ * Response from the states API endpoints
  * 
  * @public
  * @category States
  * @experimental
  */
-export interface GetStatesResponse {
+export interface StatesResponse {
     /** Array of state objects */
     states: StateOutput[];
 }
 
 /**
- * Response from the set_states API endpoint
+ * Callback function type for receiving states
  * 
  * @public
  * @category States
  * @experimental
  */
-export interface SetStatesResponse {
-    /** Optional error message */
-    error?: string;
-}
+export type StatesCallback = (states: StateOutput[]) => void;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Normalizes a URL by removing query parameters and fragment identifier
+ * @param url - The URL to normalize
+ * @returns The normalized URL without query and fragment parts
+ */
+function normalizeUrl(url: string): string {
+    try {
+        const parsedUrl = new URL(url);
+        // Remove query parameters and fragment
+        parsedUrl.search = '';
+        parsedUrl.hash = '';
+        return parsedUrl.toString();
+    } catch (error) {
+        // If URL parsing fails, return the original URL
+        console.warn('Failed to parse URL:', url, error);
+        return url;
+    }
+}
+
+/**
+ * Safely retrieves and returns the normalized URL of the current window
+ * @returns The normalized current window URL or null if not available
+ */
+export function getCurrentNormalizedUrl(): string | null {
+    try {
+        // Check if we're in a browser environment
+        if (typeof window === 'undefined' || !window.location) {
+            return null;
+        }
+
+        // Get the current URL from window.location
+        const currentUrl = window.location.href;
+
+        // Normalize the URL using the existing function
+        return normalizeUrl(currentUrl);
+    } catch (error) {
+        console.warn('Failed to get current window URL:', error);
+        return null;
+    }
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -20,6 +20,8 @@ declare const __VERSION__: string;
  * which is injected into the build by the build system.
  * 
  * @returns The SDK version string
+ * @category Initialization
+ * @public
  * @example
  * ```typescript
  * import { getVersion } from 'pumproom-sdk';

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -2,9 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { sendEnvironment, setEnvironmentListener } from '../src/environment.ts';
 import { setOnInitCallback } from '../src/callbacks.ts';
 import * as version from '../src/version.ts';
+import * as utils from '../src/utils.ts';
+
+// Mock getCurrentNormalizedUrl to avoid window dependency
+vi.mock('../src/utils.ts', () => ({
+  getCurrentNormalizedUrl: vi.fn().mockReturnValue('http://localhost/test-page')
+}));
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  // Re-mock getCurrentNormalizedUrl after restoreAllMocks
+  vi.mocked(utils.getCurrentNormalizedUrl).mockReturnValue('http://localhost/test-page');
 });
 
 describe('environment helpers', () => {
@@ -16,7 +24,7 @@ describe('environment helpers', () => {
       {
         service: 'pumproom',
         type: 'setEnvironment',
-        payload: { pageURL: window.location.href, sdkVersion: '1.0.0' }
+        payload: { pageURL: 'http://localhost/test-page', sdkVersion: '1.0.0' }
       },
       'https://pumproom.tech'
     );
@@ -41,7 +49,7 @@ describe('environment helpers', () => {
       {
         service: 'pumproom',
         type: 'setEnvironment',
-        payload: { pageURL: window.location.href, sdkVersion: '2.0.0' }
+        payload: { pageURL: 'http://localhost/test-page', sdkVersion: '2.0.0' }
       },
       'https://pumproom.tech'
     );

--- a/tests/globals.test.ts
+++ b/tests/globals.test.ts
@@ -1,10 +1,23 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fullscreen from '../src/fullscreen.ts';
-import { setConfig, getConfig, setCurrentUser, getCurrentUser } from '../src/globals.ts';
+import { 
+  setConfig, 
+  getConfig, 
+  setCurrentUser, 
+  getCurrentUser,
+  registerStates,
+  getRegisteredStates,
+  resetRegisteredStates
+} from '../src/globals.ts';
 import { init } from '../src/index.ts';
 
 beforeEach(() => {
   vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  // Reset registered states after each test
+  resetRegisteredStates();
 });
 
 describe('globals', () => {
@@ -23,5 +36,59 @@ describe('globals', () => {
     const user = { uid: '1', token: 't', is_admin: false };
     setCurrentUser(user);
     expect(getCurrentUser()).toEqual(user);
+  });
+
+  describe('state registration', () => {
+    it('registers state names', () => {
+      // Initially, no states are registered
+      expect(getRegisteredStates()).toEqual([]);
+
+      // Register some states
+      registerStates(['state1', 'state2']);
+
+      // Check that the states were registered
+      expect(getRegisteredStates()).toEqual(['state1', 'state2']);
+    });
+
+    it('throws an error if stateNames is not an array', () => {
+      // @ts-ignore - Testing runtime type checking
+      expect(() => registerStates('not-an-array')).toThrow('stateNames must be an array');
+    });
+
+    it('does not add duplicate state names', () => {
+      // Register some states
+      registerStates(['state1', 'state2']);
+
+      // Register the same states again plus a new one
+      registerStates(['state1', 'state2', 'state3']);
+
+      // Check that duplicates were not added
+      expect(getRegisteredStates()).toEqual(['state1', 'state2', 'state3']);
+    });
+
+    it('returns a copy of registered states', () => {
+      // Register some states
+      registerStates(['state1', 'state2']);
+
+      // Get the registered states
+      const states = getRegisteredStates();
+
+      // Modify the returned array
+      states.push('state3');
+
+      // Check that the original registered states were not modified
+      expect(getRegisteredStates()).toEqual(['state1', 'state2']);
+    });
+
+    it('resets registered states', () => {
+      // Register some states
+      registerStates(['state1', 'state2']);
+
+      // Reset the registered states
+      resetRegisteredStates();
+
+      // Check that the registered states were reset
+      expect(getRegisteredStates()).toEqual([]);
+    });
   });
 });

--- a/tests/instance.test.ts
+++ b/tests/instance.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { registerInstance, getInstances } from '../src/instance.ts';
+import { registerTaskInstance, getTaskInstances } from '../src/instance.ts';
 import { setEnvironmentListener } from '../src/environment.ts';
 import type { InstanceContext } from '../src/types/index.ts';
 
@@ -24,10 +24,10 @@ describe('instance module', () => {
     };
 
     // Register the instance
-    registerInstance(instanceContext);
+    registerTaskInstance(instanceContext);
 
     // Get all instances and verify our instance is included
-    const instances = getInstances();
+    const instances = getTaskInstances();
     expect(instances).toHaveProperty('test-instance-123');
     expect(instances['test-instance-123']).toEqual(instanceContext);
   });
@@ -42,14 +42,14 @@ describe('instance module', () => {
     } as InstanceContext;
 
     // Get the current instances to check the count before
-    const beforeInstances = getInstances();
+    const beforeInstances = getTaskInstances();
     const beforeCount = Object.keys(beforeInstances).length;
 
     // Try to register the invalid instance
-    registerInstance(invalidInstance);
+    registerTaskInstance(invalidInstance);
 
     // Get instances again and verify no new instance was added
-    const afterInstances = getInstances();
+    const afterInstances = getTaskInstances();
     const afterCount = Object.keys(afterInstances).length;
     expect(afterCount).toBe(beforeCount);
   });
@@ -64,17 +64,17 @@ describe('instance module', () => {
       tags: 'test-tags'
     };
 
-    registerInstance(instanceContext);
+    registerTaskInstance(instanceContext);
 
     // Get instances and modify the returned object
-    const instances = getInstances();
+    const instances = getTaskInstances();
     instances['copy-test-instance'] = {
       ...instanceContext,
       repoName: 'modified-repo'
     };
 
     // Get instances again and verify the original wasn't modified
-    const newInstances = getInstances();
+    const newInstances = getTaskInstances();
     expect(newInstances['copy-test-instance'].repoName).toBe('test-repo');
   });
 
@@ -97,15 +97,15 @@ describe('instance module', () => {
     };
 
     // Get current instances to check the count before
-    const beforeInstances = getInstances();
+    const beforeInstances = getTaskInstances();
     const beforeCount = Object.keys(beforeInstances).length;
 
     // Register both instances
-    registerInstance(instance1);
-    registerInstance(instance2);
+    registerTaskInstance(instance1);
+    registerTaskInstance(instance2);
 
     // Get instances again and verify both were added
-    const afterInstances = getInstances();
+    const afterInstances = getTaskInstances();
     expect(afterInstances).toHaveProperty('multi-test-1');
     expect(afterInstances).toHaveProperty('multi-test-2');
     expect(Object.keys(afterInstances).length).toBe(beforeCount + 2);
@@ -140,7 +140,7 @@ describe('instance module', () => {
     window.dispatchEvent(event);
 
     // Verify the instance was registered through the environment module
-    const instances = getInstances();
+    const instances = getTaskInstances();
     expect(instances).toHaveProperty('env-test-instance');
     expect(instances['env-test-instance']).toEqual(instanceContext);
   });

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -1,37 +1,142 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { retrieveData, storeData } from '../src/storage.ts';
-import {USER_STORAGE_KEY} from "../src/constants.ts";
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { retrieveData, storeData, generateStateKey, saveStatesToLocalStorage, getStatesFromLocalStorage } from '../src/storage.ts';
+import { USER_STORAGE_KEY, STORAGE_PREFIX } from "../src/constants.ts";
+import * as utils from '../src/utils.ts';
+
+// Mock getCurrentNormalizedUrl to avoid window dependency
+vi.mock('../src/utils.ts', () => ({
+  getCurrentNormalizedUrl: vi.fn().mockReturnValue('http://localhost/test-page')
+}));
 
 beforeEach(() => {
-  localStorage.clear();
+  if (typeof localStorage !== 'undefined') {
+    localStorage.clear();
+  }
+  vi.clearAllMocks();
 });
 
 describe('storage', () => {
-  it('returns null when storage empty', () => {
-    expect(retrieveData(USER_STORAGE_KEY)).toBeNull();
+  describe('basic storage operations', () => {
+    it('returns null when storage empty', () => {
+      expect(retrieveData(USER_STORAGE_KEY)).toBeNull();
+    });
+
+    it('saves and reads user', () => {
+      const user = { uid: 'u', token: 't', is_admin: false };
+      storeData(USER_STORAGE_KEY, user);
+      expect(retrieveData(USER_STORAGE_KEY)).toEqual(user);
+    });
+
+    it('handles JSON parse error', () => {
+      localStorage.setItem('pumproomUser', '{bad json');
+      expect(retrieveData(USER_STORAGE_KEY)).toBeNull();
+    });
+
+    it('ignores storage failures', () => {
+      const orig = global.localStorage;
+      global.localStorage = {
+        setItem: () => { throw new Error('fail'); },
+        getItem: orig.getItem.bind(orig),
+        clear: orig.clear.bind(orig),
+        removeItem: orig.removeItem.bind(orig),
+      } as any;
+      const user = { uid: 'u', token: 't', is_admin: false };
+      expect(() => storeData(USER_STORAGE_KEY, user)).not.toThrow();
+      global.localStorage = orig;
+    });
   });
 
-  it('saves and reads user', () => {
-    const user = { uid: 'u', token: 't', is_admin: false };
-    storeData(USER_STORAGE_KEY, user);
-    expect(retrieveData(USER_STORAGE_KEY)).toEqual(user);
-  });
+  describe('state storage operations', () => {
+    it('generates correct state key', () => {
+      const stateName = 'testState';
+      const userId = 'user123';
 
-  it('handles JSON parse error', () => {
-    localStorage.setItem('pumproomUser', '{bad json');
-    expect(retrieveData(USER_STORAGE_KEY)).toBeNull();
-  });
+      // getCurrentNormalizedUrl is already mocked to return 'http://localhost/test-page'
+      const key = generateStateKey(stateName, userId);
+      expect(key).toBe(`${STORAGE_PREFIX}:http://localhost/test-page:${stateName}:${userId}`);
 
-  it('ignores storage failures', () => {
-    const orig = global.localStorage;
-    global.localStorage = {
-      setItem: () => { throw new Error('fail'); },
-      getItem: orig.getItem.bind(orig),
-      clear: orig.clear.bind(orig),
-      removeItem: orig.removeItem.bind(orig),
-    } as any;
-    const user = { uid: 'u', token: 't', is_admin: false };
-    expect(() => storeData(USER_STORAGE_KEY, user)).not.toThrow();
-    global.localStorage = orig;
+      // Verify that getCurrentNormalizedUrl was called
+      expect(utils.getCurrentNormalizedUrl).toHaveBeenCalled();
+    });
+
+    it('saves states to localStorage', () => {
+      const userId = 'user123';
+      const states = [
+        { name: 'state1', value: 'value1', data_type: 'str' },
+        { name: 'state2', value: 42, data_type: 'int' }
+      ];
+
+      saveStatesToLocalStorage(states, userId);
+
+      // Verify states were saved
+      const key1 = generateStateKey('state1', userId);
+      const key2 = generateStateKey('state2', userId);
+
+      const savedState1 = JSON.parse(localStorage.getItem(key1) || '');
+      const savedState2 = JSON.parse(localStorage.getItem(key2) || '');
+
+      expect(savedState1).toEqual(states[0]);
+      expect(savedState2).toEqual(states[1]);
+    });
+
+    it('retrieves states from localStorage', () => {
+      const userId = 'user123';
+      const states = [
+        { name: 'state1', value: 'value1', data_type: 'str' },
+        { name: 'state2', value: 42, data_type: 'int' }
+      ];
+
+      // Save states directly
+      states.forEach(state => {
+        const key = generateStateKey(state.name, userId);
+        localStorage.setItem(key, JSON.stringify(state));
+      });
+
+      // Retrieve states
+      const retrievedStates = getStatesFromLocalStorage(['state1', 'state2'], userId);
+      expect(retrievedStates).toEqual(states);
+    });
+
+    it('handles missing states gracefully', () => {
+      const userId = 'user123';
+      const retrievedStates = getStatesFromLocalStorage(['nonexistent'], userId);
+      expect(retrievedStates).toEqual([]);
+    });
+
+    it('handles localStorage errors when saving', () => {
+      const orig = global.localStorage;
+      global.localStorage = {
+        setItem: () => { throw new Error('fail'); },
+        getItem: orig.getItem.bind(orig),
+        clear: orig.clear.bind(orig),
+        removeItem: orig.removeItem.bind(orig),
+      } as any;
+
+      const userId = 'user123';
+      const states = [{ name: 'state1', value: 'value1', data_type: 'str' }];
+
+      // Should not throw
+      expect(() => saveStatesToLocalStorage(states, userId)).not.toThrow();
+
+      global.localStorage = orig;
+    });
+
+    it('handles localStorage errors when retrieving', () => {
+      const orig = global.localStorage;
+      global.localStorage = {
+        setItem: orig.setItem.bind(orig),
+        getItem: () => { throw new Error('fail'); },
+        clear: orig.clear.bind(orig),
+        removeItem: orig.removeItem.bind(orig),
+      } as any;
+
+      const userId = 'user123';
+
+      // Should not throw and return empty array
+      const retrievedStates = getStatesFromLocalStorage(['state1'], userId);
+      expect(retrievedStates).toEqual([]);
+
+      global.localStorage = orig;
+    });
   });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getCurrentNormalizedUrl } from '../src/utils.ts';
+
+describe('utils', () => {
+  // Store the original window object
+  const originalWindow = global.window;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    // Restore the original window object after each test
+    // Use Object.defineProperty instead of direct assignment to handle cases where window is defined with a getter
+    Object.defineProperty(global, 'window', {
+      configurable: true,
+      writable: true,
+      value: originalWindow
+    });
+  });
+
+  describe('normalizeUrl', () => {
+    // Since normalizeUrl is not exported, we'll test it indirectly through getCurrentNormalizedUrl
+    it('removes query parameters and fragment from URL', () => {
+      // Mock window.location
+      global.window = {
+        location: {
+          href: 'https://example.com/path?query=value#fragment'
+        }
+      } as any;
+
+      const result = getCurrentNormalizedUrl();
+      expect(result).toBe('https://example.com/path');
+    });
+
+    it('handles URLs with no query parameters or fragment', () => {
+      // Mock window.location
+      global.window = {
+        location: {
+          href: 'https://example.com/path'
+        }
+      } as any;
+
+      const result = getCurrentNormalizedUrl();
+      expect(result).toBe('https://example.com/path');
+    });
+
+    it('preserves trailing slash if present', () => {
+      // Mock window.location
+      global.window = {
+        location: {
+          href: 'https://example.com/path/?query=value#fragment'
+        }
+      } as any;
+
+      const result = getCurrentNormalizedUrl();
+      expect(result).toBe('https://example.com/path/');
+    });
+
+    it('returns original URL when URL parsing fails', () => {
+      // Mock console.warn to verify it's called
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Create an invalid URL that will cause the URL constructor to throw
+      const invalidUrl = 'invalid://url:with:multiple:colons';
+
+      // Mock window.location with the invalid URL
+      global.window = {
+        location: {
+          href: invalidUrl
+        }
+      } as any;
+
+      const result = getCurrentNormalizedUrl();
+
+      // Verify the result is the original invalid URL
+      expect(result).toBe(invalidUrl);
+
+      // Verify console.warn was called with the expected arguments
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Failed to parse URL:',
+        invalidUrl,
+        expect.any(Error)
+      );
+
+      // Restore console.warn
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('getCurrentNormalizedUrl', () => {
+    it('returns null when window is undefined', () => {
+      // Set window to undefined
+      global.window = undefined as any;
+
+      const result = getCurrentNormalizedUrl();
+      expect(result).toBeNull();
+    });
+
+    it('returns null when window.location is undefined', () => {
+      // Set window.location to undefined
+      global.window = {} as any;
+
+      const result = getCurrentNormalizedUrl();
+      expect(result).toBeNull();
+    });
+
+    it('handles errors gracefully', () => {
+      // Mock window.location to throw an error when accessed
+      Object.defineProperty(global, 'window', {
+        get: () => {
+          throw new Error('Test error');
+        }
+      });
+
+      const result = getCurrentNormalizedUrl();
+      expect(result).toBeNull();
+    });
+
+    it('returns normalized URL when window.location is available', () => {
+      // Mock window.location
+      global.window = {
+        location: {
+          href: 'https://example.com/path?query=value#fragment'
+        }
+      } as any;
+
+      const result = getCurrentNormalizedUrl();
+      expect(result).toBe('https://example.com/path');
+    });
+  });
+});

--- a/typedoc.json
+++ b/typedoc.json
@@ -12,6 +12,8 @@
   "name": "PumpRoom SDK",
   "includeVersion": true,
   "categorizeByGroup": true,
+  "defaultCategory": "Official",
+  "categoryOrder": ["Official", "Experimental", "*"],
   "searchInComments": true,
   "hideGenerator": true,
   "customFooterHtml": "PumpRoom SDK",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,9 +1,10 @@
 {
   "$schema": "https://typedoc.org/schema.json",
+  "tsconfig": "tsconfig.build.json",
   "entryPoints": ["./src/index.ts"],
   "entryPointStrategy": "resolve",
   "out": "public/docs",
-  "exclude": ["**/*.test.ts", "**/tests/**", "**/node_modules/**", "**/vite-env.d.ts"],
+  "exclude": ["**/node_modules/**", "**/vite-env.d.ts"],
   "excludePrivate": true,
   "excludeProtected": false,
   "excludeExternals": true,
@@ -11,7 +12,8 @@
   "readme": "README.md",
   "name": "PumpRoom SDK",
   "includeVersion": true,
-  "categorizeByGroup": true,
+  "categorizeByGroup": false,
+  "categoryOrder": ["Initialization", "Authentication", "Callbacks", "Tasks", "*"],
   "searchInComments": true,
   "hideGenerator": true,
   "customFooterHtml": "PumpRoom SDK",
@@ -26,10 +28,18 @@
     "notDocumented": true
   },
   "visibilityFilters": {
-    "protected": true,
+    "protected": false,
     "private": false,
-    "inherited": true,
-    "external": false
+    "inherited": false,
+    "external": false,
+    "@experimental": true
+  },
+  "navigation": {
+    "includeCategories": true,
+    "includeGroups": true,
+    "includeFolders": true,
+    "compactFolders": false,
+    "excludeReferences": false
   },
   "cleanOutputDir": true,
   "disableSources": false,

--- a/typedoc.json
+++ b/typedoc.json
@@ -12,8 +12,6 @@
   "name": "PumpRoom SDK",
   "includeVersion": true,
   "categorizeByGroup": true,
-  "defaultCategory": "Official",
-  "categoryOrder": ["Official", "Experimental", "*"],
   "searchInComments": true,
   "hideGenerator": true,
   "customFooterHtml": "PumpRoom SDK",

--- a/vite.config.site.ts
+++ b/vite.config.site.ts
@@ -41,7 +41,11 @@ export default defineConfig(({command, mode}) => {
             },
         },
         server: {
-            port: 8002,
+            port: 8005,
+            open: '/',
+        },
+        preview: {
+            port: 8005,
             open: '/',
         },
         plugins: [


### PR DESCRIPTION
## Summary
- add `defaultCategory` and `categoryOrder` to typedoc config
- mark state related constants, methods and types as `@category Experimental`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fa530e884832489a6f56749d48991